### PR TITLE
multiple NIC configurations 

### DIFF
--- a/components/9990-netbase.sh
+++ b/components/9990-netbase.sh
@@ -33,6 +33,7 @@ Netbase ()
 cat > "${IFFILE}" << EOF
 auto lo
 iface lo inet loopback
+source /etc/network/interfaces.d/*
 
 EOF
 


### PR DESCRIPTION
a tiny modification of default /etc/network/interface file to allow multiple nic to be configured using standard /etc/network/interfaces.d/
no impact on default behaviour because  /etc/network/interfaces.d/ is empty.